### PR TITLE
Adding a container for neo4j 2.3.2

### DIFF
--- a/neo4j/2.3.2/Dockerfile
+++ b/neo4j/2.3.2/Dockerfile
@@ -1,0 +1,6 @@
+FROM neo4j/neo4j:2.3.2
+
+# Resolves virtualbox guest additions shared volume problem by moving
+# rrd storage.
+RUN sed -i -e "s|org.neo4j.server.webadmin.rrdb.location=.*|org.neo4j.server.webadmin.rrdb.location=/tmp/rrd|g" /var/lib/neo4j/conf/neo4j-server.properties && \
+    touch /tmp/rrd


### PR DESCRIPTION
Upgraded our neo4j container to 2.3.2 so that I can use `DETACH DELETE` locally; also this mimics the version we're on in production. Set up to trigger builds in Docker Hub. Closes https://github.com/industrydive/datadive/issues/286
