### PR TITLE
Update docs-base container

### DIFF
--- a/docs-base/3.0/Dockerfile
+++ b/docs-base/3.0/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:wheezy
+# Never prompts the user for choices on installation/configuration of packages
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM linux
+# Work around initramfs-tools running on kernel 'upgrade': <http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=594189>
+ENV INITRD No
+RUN apt-get update -yqq \
+    && apt-get install -yqq --no-install-recommends \
+    netcat \
+    curl \
+    git \
+    python-pip \
+    python-dev \
+    libmysqlclient-dev \
+    libkrb5-dev \
+    libsasl2-dev \
+    libssl-dev \
+    libffi-dev \
+    build-essential \
+    python-sphinx \
+    libpq-dev \
+    && apt-get clean \
+    && rm -rf \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/* \
+    /usr/share/man \
+    /usr/share/doc \
+    /usr/share/doc-base
+# Install airflow and its dependencies.
+RUN pip install cryptography \
+    && pip install airflow==1.6.2 \
+    && pip install airflow[mysql]==1.6.2 \
+    && pip install airflow[celery]==1.6.2 \
+    && pip install sphinx-rtd-theme==0.1.9
+# Base command runs make on working dir's make file.
+# Docs container must expose its Makefile at its working dir.
+CMD ["make", "html"]

--- a/docs-base/3.0/README.md
+++ b/docs-base/3.0/README.md
@@ -1,0 +1,3 @@
+# Base container for generating Docs
+
+This image includes some common packages for building our docs container.


### PR DESCRIPTION
Adding a new docs base that installs git since we now have pip dependencies off of a git repo for caribou. Also updates docs container to airflow 1.6.2 since we are on that now, must have gotten missed before. Set up to trigger builds on Docker Hub.
